### PR TITLE
add retries for upload_url status check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.1.3
+* Added retry for upload_url status check (https://github.com/CryptoHamsters/uploadcare_ex/pull/4)
 # 0.1.2
 * Added default value to accept_header (https://github.com/exthereum/ethereumex/pull/2)
 * Added `store` parameter to upload_url (https://github.com/exthereum/ethereumex/pull/2)

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,4 +4,6 @@ config :uploadcare_ex,
   public_key: "3f5c4ce6fcdaf7aeace8",
   private_key: "06aa7fca4eee96801cc4",
   retry_period: 1_000,
-  retry_expiry: 5_000
+  retry_expiry: 5_000,
+  upload_url_retry_period: 300,
+  upload_url_retry_expiry: 1_500

--- a/lib/uploadcare_ex/config.ex
+++ b/lib/uploadcare_ex/config.ex
@@ -57,6 +57,16 @@ defmodule UploadcareEx.Config do
     Application.get_env(:uploadcare_ex, :retry_expiry) || 5_000
   end
 
+  @spec upload_url_retry_period() :: number()
+  def upload_url_retry_period do
+    Application.get_env(:uploadcare_ex, :upload_url_retry_period) || 300
+  end
+
+  @spec upload_url_retry_expiry() :: number()
+  def upload_url_retry_expiry do
+    Application.get_env(:uploadcare_ex, :upload_url_retry_expiry) || 20_000
+  end
+
   @spec get_env_var!(atom()) :: binary() | number()
   defp get_env_var!(key) do
     case Application.get_env(:uploadcare_ex, key) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,11 +4,11 @@ defmodule UploadcareEx.MixProject do
   def project do
     [
       app: :uploadcare_ex,
-      version: "0.1.2",
+      version: "0.1.3",
       elixir: "~> 1.6",
       description: "Elixir wrapper for Uploadcare API",
       package: [
-        maintainers: ["Ayrat Badykov"],
+        maintainers: ["Ayrat Badykov", "Vitali Kharevich"],
         licenses: ["MIT"],
         links: %{"GitHub" => "https://github.com/CryptoHamsters/uploadcare_ex"}
       ],


### PR DESCRIPTION
вообщем проблема с проверкой статуса загрузки картинки по url, мы слишком быстро запрашиваем данные о состоянии загрузки, и uploadcare возвращает такой ответ `%{body: %{"status" => "unknown"}, status_code: 200}`, надо чтобы в таком случае происходил повтор запроса с некоторой задержкой