### PR TITLE
Fix upload_url token status

### DIFF
--- a/lib/uploadcare_ex/api/upload/url.ex
+++ b/lib/uploadcare_ex/api/upload/url.ex
@@ -11,8 +11,8 @@ defmodule UploadcareEx.API.Upload.Url do
   @spec upload(binary()) :: {:ok, map()} | {:error, any()}
   def upload(url) do
     with {:ok, token} <- url |> try_to_upload(),
-         {:ok, result} <- token |> check_token_status() do
-      {:ok, result}
+         {:ok, _result} <- token |> check_token_status() do
+      {:ok, token}
     end
   end
 


### PR DESCRIPTION
When we upload file by url, got status: `{:ok, %{body: %{"status" => "waiting"}, status_code: 200}}` but not token.